### PR TITLE
Reuse HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();
@@ -98,7 +98,7 @@ For more information how to build a paramaters HashMap see [serpapi.com document
 
 ```rust
 let default = HashMap::<String, String>::new();
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 let mut parameter = HashMap::<String, String>::new();
 parameter.insert("q".to_string(), "Austin".to_string());
 let data = client.location(parameter).await.expect("request");
@@ -114,7 +114,7 @@ It returns the first 3 locations matching Austin (Texas, Texas, Rochester)
 let mut default = HashMap::<String, String>::new();
 default.insert("engine".to_string(), "google".to_string());
 default.insert("api_key".to_string(), "your_secret_key".to_string());
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // initialize the search engine
 let mut parameter = HashMap::<String, String>::new();
@@ -186,7 +186,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "bing".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -236,7 +236,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "baidu".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -286,7 +286,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "yahoo".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -336,7 +336,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "youtube".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -386,7 +386,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "walmart".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -436,7 +436,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "ebay".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -486,7 +486,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "naver".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -536,7 +536,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "home_depot".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -586,7 +586,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "apple_app_store".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -636,7 +636,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "duckduckgo".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -686,7 +686,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -737,7 +737,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_scholar".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -787,7 +787,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_autocomplete".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -837,7 +837,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_product".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -888,7 +888,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_reverse_image".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -939,7 +939,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_events".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -989,7 +989,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_local_services".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -1040,7 +1040,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_maps".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -1092,7 +1092,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_jobs".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -1142,7 +1142,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_play".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();
@@ -1194,7 +1194,7 @@ let mut default = HashMap::new();
 default.insert("api_key".to_string(), "your_secret_api_key".to_string());
 default.insert("engine".to_string(), "google_images".to_string());
 // initialize the search engine
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // let's search for coffee in Austin, TX
 let mut parameter = HashMap::new();

--- a/README.md.erb
+++ b/README.md.erb
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();
@@ -113,7 +113,7 @@ For more information how to build a paramaters HashMap see [serpapi.com document
 
 ```rust
 let default = HashMap::<String, String>::new();
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 let mut parameter = HashMap::<String, String>::new();
 parameter.insert("q".to_string(), "Austin".to_string());
 let data = client.location(parameter).await.expect("request");
@@ -129,7 +129,7 @@ It returns the first 3 locations matching Austin (Texas, Texas, Rochester)
 let mut default = HashMap::<String, String>::new();
 default.insert("engine".to_string(), "google".to_string());
 default.insert("api_key".to_string(), "your_secret_key".to_string());
-let client = Client::new(default);
+let client = Client::new(default).unwrap();
 
 // initialize the search engine
 let mut parameter = HashMap::<String, String>::new();

--- a/examples/apple_app_store_search.rs
+++ b/examples/apple_app_store_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "apple_app_store".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/baidu_search.rs
+++ b/examples/baidu_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "baidu".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/bing_search.rs
+++ b/examples/bing_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "bing".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/duckduckgo_search.rs
+++ b/examples/duckduckgo_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "duckduckgo".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/ebay_search.rs
+++ b/examples/ebay_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "ebay".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_autocomplete_search.rs
+++ b/examples/google_autocomplete_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_autocomplete".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_events_search.rs
+++ b/examples/google_events_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_events".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_images_search.rs
+++ b/examples/google_images_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_images".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_jobs_search.rs
+++ b/examples/google_jobs_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_jobs".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_local_services_search.rs
+++ b/examples/google_local_services_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_local_services".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_maps_search.rs
+++ b/examples/google_maps_search.rs
@@ -21,12 +21,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_maps".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();
     parameter.insert("q".to_string(), "pizza".to_string());
-    parameter.insert("ll".to_string(), "@40.7455096,-74.0083012,15.1z".to_string());
+    parameter.insert(
+        "ll".to_string(),
+        "@40.7455096,-74.0083012,15.1z".to_string(),
+    );
     parameter.insert("type".to_string(), "search".to_string());
     // copy search parameter for the html search
     let mut html_parameter = HashMap::new();

--- a/examples/google_play_search.rs
+++ b/examples/google_play_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_play".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_product_search.rs
+++ b/examples/google_product_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_product".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_reverse_image_search.rs
+++ b/examples/google_reverse_image_search.rs
@@ -21,11 +21,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_reverse_image".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();
-    parameter.insert("image_url".to_string(), "https://i.imgur.com/5bGzZi7.jpg".to_string());
+    parameter.insert(
+        "image_url".to_string(),
+        "https://i.imgur.com/5bGzZi7.jpg".to_string(),
+    );
     parameter.insert("max_results".to_string(), "1".to_string());
     // copy search parameter for the html search
     let mut html_parameter = HashMap::new();

--- a/examples/google_scholar_search.rs
+++ b/examples/google_scholar_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google_scholar".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/google_search.rs
+++ b/examples/google_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "google".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/home_depot_search.rs
+++ b/examples/home_depot_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "home_depot".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/naver_search.rs
+++ b/examples/naver_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "naver".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/walmart_search.rs
+++ b/examples/walmart_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "walmart".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/yahoo_search.rs
+++ b/examples/yahoo_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "yahoo".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/examples/youtube_search.rs
+++ b/examples/youtube_search.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     default.insert("api_key".to_string(), api_key);
     default.insert("engine".to_string(), "youtube".to_string());
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // let's search for coffee in Austin, TX
     let mut parameter = HashMap::new();

--- a/src/serpapi.rs
+++ b/src/serpapi.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 pub struct Client {
     // search parameter like: q=coffee for google
     pub parameter: HashMap<String, String>,
+    pub http: reqwest::Client,
 }
 
 const HOST: &str = "http://serpapi.com";
@@ -22,10 +23,11 @@ impl Client {
     /// initialize a serp api client with default parameters.
     /// # Arguments
     /// * `parameter` allows to set default parameter like: api_key or engine for the client.
-    pub fn new(parameter: HashMap<String, String>) -> Client {
-        Client {
-            parameter: parameter,
-        }
+    pub fn new(parameter: HashMap<String, String>) -> Result<Client, Box<dyn std::error::Error>> {
+        let http = reqwest::Client::builder().build()?;
+        let client = Client { parameter, http };
+
+        Ok(client)
     }
 
     /// execute a search on serpapi.com
@@ -44,7 +46,7 @@ impl Client {
     ///  default.insert("engine".to_string(), "google".to_string());
     ///  default.insert("api_key".to_string(), "secret_api_key".to_string());
     ///  // initialize the serpapi client
-    ///  let client = Client::new(default);
+    ///  let client = Client::new(default).unwrap();
     ///  let mut parameter = HashMap::<String, String>::new();
     ///  parameter.insert("q".to_string(), "coffee".to_string());
     ///  parameter.insert(
@@ -79,7 +81,7 @@ impl Client {
     /// default.insert("engine".to_string(), "google".to_string());
     /// default.insert("api_key".to_string(), "secret_api_key".to_string());
     /// // initialize the search engine
-    /// let client = Client::new(default);
+    /// let client = Client::new(default).unwrap();
     /// let mut parameter = HashMap::<String, String>::new();
     /// parameter.insert("q".to_string(), "coffee".to_string());
     /// parameter.insert("location".to_string(), "Austin, TX, Texas, United States".to_string());
@@ -172,8 +174,7 @@ impl Client {
 
         let mut url = HOST.to_string();
         url.push_str(endpoint);
-        let client = reqwest::Client::builder().build()?;
-        let res = client.get(url).query(&query).send().await?;
+        let res = self.http.get(url).query(&query).send().await?;
         let body = res.text().await?;
         Ok(body)
     }

--- a/tests/serpapi-test.rs
+++ b/tests/serpapi-test.rs
@@ -19,7 +19,7 @@ async fn search() {
     default.insert("api_key".to_string(), api_key());
 
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     let mut parameter = HashMap::<String, String>::new();
     parameter.insert("q".to_string(), "coffee".to_string());
@@ -44,7 +44,7 @@ async fn html() {
     default.insert("api_key".to_string(), api_key());
 
     // initialize the search engine
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     let mut parameter = HashMap::<String, String>::new();
     parameter.insert("q".to_string(), "coffee".to_string());
@@ -59,7 +59,7 @@ async fn html() {
 #[tokio::test]
 async fn location() {
     let default = HashMap::<String, String>::new();
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
     let mut parameter = HashMap::<String, String>::new();
     parameter.insert("q".to_string(), "Austin".to_string());
     let data = client.location(parameter).await.expect("request");
@@ -73,7 +73,7 @@ async fn location() {
 
 #[tokio::test]
 async fn account() {
-    let client = Client::new(HashMap::<String, String>::new());
+    let client = Client::new(HashMap::<String, String>::new()).unwrap();
     let mut parameter = HashMap::<String, String>::new();
     parameter.insert("api_key".to_string(), api_key());
     let account = client.account(parameter).await.expect("request");
@@ -86,7 +86,7 @@ async fn search_archive() {
     let mut default = HashMap::<String, String>::new();
     default.insert("engine".to_string(), "google".to_string());
     default.insert("api_key".to_string(), api_key());
-    let client = Client::new(default);
+    let client = Client::new(default).unwrap();
 
     // initialize the search engine
     let mut parameter = HashMap::<String, String>::new();


### PR DESCRIPTION
`reqwest` client should be created once and then reused for all the requests. It will prevent creation of redundant HTTP connections and save from possible CPU spikes (especially on macOS).